### PR TITLE
Fix: handle zero-valued prices

### DIFF
--- a/src/Dilicom/RestClient.php
+++ b/src/Dilicom/RestClient.php
@@ -119,7 +119,7 @@ class RestClient
      */
     protected function checkEbookData(array $ebook)
     {
-        if (empty($ebook["ean13"]) || empty($ebook["glnDistributor"]) || empty($ebook["unitPrice"])) {
+        if (!isset($ebook["ean13"]) || !isset($ebook["glnDistributor"]) || !isset($ebook["unitPrice"])) {
             throw new \InvalidArgumentException("Given ebook is badly formed. Expected something like array('ean13' => 'xxx', 'glnDistributor' => 'xxx', 'unitPrice' => 'x'), got : " . serialize($ebook));
         }
     }

--- a/src/Dilicom/RestClient.php
+++ b/src/Dilicom/RestClient.php
@@ -119,7 +119,7 @@ class RestClient
      */
     protected function checkEbookData(array $ebook)
     {
-        if (!isset($ebook["ean13"]) || !isset($ebook["glnDistributor"]) || !isset($ebook["unitPrice"])) {
+        if (!isset($ebook["ean13"], $ebook["glnDistributor"], $ebook["unitPrice"])) {
             throw new \InvalidArgumentException("Given ebook is badly formed. Expected something like array('ean13' => 'xxx', 'glnDistributor' => 'xxx', 'unitPrice' => 'x'), got : " . serialize($ebook));
         }
     }

--- a/tests/unit/Dilicom/RestClient.php
+++ b/tests/unit/Dilicom/RestClient.php
@@ -59,7 +59,7 @@ class RestClient extends atoum\test
         $this->calling($this->http_connector_mock)->get = $response;
 
         $availability = $this->tested_client->getEbooksAvailabilities(array(
-            array("ean13" => "9780000000000", "glnDistributor" => "3330000000000", "unitPrice" => 7),
+            array("ean13" => "9780000000000", "glnDistributor" => "3330000000000", "unitPrice" => 0),
             array("ean13" => "9770000000000", "glnDistributor" => "3230000000000", "unitPrice" => 5),
         ));
 
@@ -75,7 +75,7 @@ class RestClient extends atoum\test
                     "query" => array(
                         "checkAvailabilityLines[0].ean13" => "9780000000000",
                         "checkAvailabilityLines[0].glnDistributor" => "3330000000000",
-                        "checkAvailabilityLines[0].unitPrice" => "7",
+                        "checkAvailabilityLines[0].unitPrice" => "0",
                         "checkAvailabilityLines[1].ean13" => "9770000000000",
                         "checkAvailabilityLines[1].glnDistributor" => "3230000000000",
                         "checkAvailabilityLines[1].unitPrice" => "5",


### PR DESCRIPTION
Empty gueule quand on a un prix à zéro évidemment. Du coup j'utilise isset. Le test est donc moins discriminant (on peut fournir des valeurs vides sans que ça gueule), mais pour moi ça suffit : le développeur a bien formatté son tableau, il est juste vide.
